### PR TITLE
Update DeviceConnection.java

### DIFF
--- a/escposprinter/src/main/java/com/dantsu/escposprinter/connection/DeviceConnection.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/connection/DeviceConnection.java
@@ -53,9 +53,9 @@ public abstract class DeviceConnection {
         try {
             this.stream.write(this.data);
             this.stream.flush();
-            this.data = new byte[0];
 
-            int waitingTime = addWaitingTime + (int) Math.floor(this.data.length / 16f);
+            int waitingTime = addWaitingTime + this.data.length / 16;
+            this.data = new byte[0];
             if(waitingTime > 0) {
                 Thread.sleep(waitingTime);
             }


### PR DESCRIPTION
Bug fixed: Data length used to calculate waitingTime was always zero, because it was taken from new empty array.
That was the reason of problems with printing images and qr codes.

Also I don't see any reason to use floating-point arithmetic to calculate waitingTime, so I removed it.